### PR TITLE
Upgrade posthtml to version 0.16.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",
     "htmlnano": "^1.0.0",
-    "posthtml": "^0.15.2",
+    "posthtml": "^0.16.4",
     "posthtml-hash": "^1.2.2",
     "rimraf": "^3.0.2",
     "rollup": "^2.51.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,7 @@ function hashStatic() {
         // https://github.com/posthtml/htmlnano
         htmlnano(),
       ])
-        .process(fs.readFileSync(`${OUT_DIR}/index.html`))
+        .process(fs.readFileSync(`${OUT_DIR}/index.html`, 'utf-8'))
         .then((result) =>
           fs.writeFileSync(`${OUT_DIR}/index.html`, result.html)
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,6 +1024,11 @@ is-html@^1.1.0:
   dependencies:
     html-tags "^1.0.0"
 
+is-json@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-json/-/is-json-2.0.1.tgz#6be166d144828a131d686891b983df62c39491ff"
+  integrity sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8=
+
 is-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
@@ -1623,10 +1628,24 @@ posthtml-parser@^0.7.2:
   dependencies:
     htmlparser2 "^6.0.0"
 
+posthtml-parser@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.9.0.tgz#8e7d817eb6c27885b9c7395007371d4363a5867d"
+  integrity sha512-Ybw75S+aNJuXCoCUBF2drLRip18cwbT4IBKAT6Xx7VU6FxjuDIV5VofPZRQzgwzGsASZ++5JpRhK3vagPZ4JIQ==
+  dependencies:
+    htmlparser2 "^6.0.0"
+
 posthtml-render@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.4.0.tgz#40114070c45881cacb93347dae3eff53afbcff13"
   integrity sha512-W1779iVHGfq0Fvh2PROhCe2QhB8mEErgqzo1wpIt36tCgChafP+hbXIhLDOM8ePJrZcFs0vkNEtdibEWVqChqw==
+
+posthtml-render@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-2.0.6.tgz#f39035b133f1cea1a879cba3982a7eaa1fc06c34"
+  integrity sha512-AvjM4yfEtjhbpZdtLOWfnezgojEtgeejSxrjTAvfr5phXjPcZQyB5QiOvYeU+rrTF0u+eqqlJrs8HS3nrPexGQ==
+  dependencies:
+    is-json "^2.0.1"
 
 posthtml@^0.15.0, posthtml@^0.15.2:
   version "0.15.2"
@@ -1635,6 +1654,14 @@ posthtml@^0.15.0, posthtml@^0.15.2:
   dependencies:
     posthtml-parser "^0.7.2"
     posthtml-render "^1.3.1"
+
+posthtml@^0.16.4:
+  version "0.16.4"
+  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.16.4.tgz#4f9b326357a39a820376fb065aa55bb1d313c97a"
+  integrity sha512-32VVeMtkoUrWI84etFPBBhOOJS19WAJDxJMLYi3dKma2sPtDDpO2CrR5dV8rVMPwZoAeVYxIdpaE4aqY12ibOA==
+  dependencies:
+    posthtml-parser "^0.9.0"
+    posthtml-render "^2.0.6"
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
First of all, thank you for creating this template! I just implemented it in my own project.

During this process, I found that using the latest version of `posthtml` resulted in an error caused by an attempted string function on a Buffer. This is because `readFileSync` on line 32 of `rollup.config.js` doesn't include the `'utf-8'` option. I'm not sure if this is something that varies with node versions, but I had to add this option with node v14.16.0.

I do not see that this option would cause any unexpected issues since the `posthtml().process` function needs a string to work with.